### PR TITLE
修正 Taobao::Product 的一些错误

### DIFF
--- a/lib/taobao/base.rb
+++ b/lib/taobao/base.rb
@@ -29,7 +29,7 @@ module Taobao
   end
   
   def self.append_required_options(options)
-    options.merge({
+    options.merge!({
       app_key:     @public_key,
       format:      :json,
       v:           API_VERSION,

--- a/lib/taobao/product.rb
+++ b/lib/taobao/product.rb
@@ -15,6 +15,7 @@ class Taobao::Product
 
   def initialize(product_properties)
     @all_properties_fetched = false
+    @properties = []
 
     if Hash === product_properties
       hash_to_object(product_properties)
@@ -25,7 +26,7 @@ class Taobao::Product
   end
 
   def method_missing(method_name, *args, &block)
-    unless OTHER_PROPERTIES.include? method_name
+    unless @properties.include? method_name
       super
     else
       fetch_full_data unless @all_properties_fetched
@@ -37,6 +38,7 @@ class Taobao::Product
   def hash_to_object(hash)
     hash.each do |k, v|
       self.instance_variable_set "@#{k}", v
+      @properties.push k unless @properties.include? k
     end
   end
 

--- a/lib/taobao/product.rb
+++ b/lib/taobao/product.rb
@@ -9,10 +9,10 @@ class Taobao::Product
     :approve_status, :postage_id, :product_id, :auction_point,
     :property_alias, :item_img, :prop_img, :sku, :video, :outer_id,
     :is_virtual]
-  
+
   attr_reader *BASIC_PROPERTIES
   alias :id :num_iid
-  
+
   def initialize(product_properties)
     @all_properties_fetched = false
 
@@ -23,7 +23,7 @@ class Taobao::Product
       fetch_full_data
     end
   end
-  
+
   def method_missing(method_name, *args, &block)
     unless OTHER_PROPERTIES.include? method_name
       super
@@ -32,14 +32,14 @@ class Taobao::Product
       self.instance_variable_get "@#{method_name}"
     end
   end
-  
+
   private
   def hash_to_object(hash)
     hash.each do |k, v|
       self.instance_variable_set "@#{k}", v
     end
   end
-  
+
   def fetch_full_data
     fields = (BASIC_PROPERTIES + OTHER_PROPERTIES).join ','
     params = {method: 'taobao.item.get', fields: fields, num_iid: id}


### PR DESCRIPTION
- 合并参数的时候应该是 options.merge! 吧
- 原来的写法会导致某些产品属性无法获取，比如：item_imgs
